### PR TITLE
Fix run-time usage of require()

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ var escape = require('escape-html')
   , map = require('map-stream')
   , clone = require('clone')
   , extend = require('xtend')
+  , colors_base = require('./colors')
 
 /**
  * Returns a through-stream that converts ANSI escape
@@ -15,14 +16,13 @@ var escape = require('escape-html')
  */
 function createStream(options) {
   var options = options || {}
-    , colors = require('./colors')
     , groupStack = [] // Keeps track of opened span types.
     , spanStack = []  // Keeps track of opened span markup.
     , chunked = options.chunked && escape(options.chunked) || false
     , groups
     , stream
-
-  colors = clone(colors[options.classes ? 'classes' : 'inline'])
+    , colors = clone(colors_base[options.classes ? 'classes' : 'inline'])
+    
   colors = extend(colors, options.theme || {})
 
   colors.resets = colors.resets || [{'0':false}]


### PR DESCRIPTION
This is generally bad because it does synchronous file I/O, which means if your server is under heavy disk load when this function is first called, the entire node process will stop serving requests until it can get disk access.
This is specifically bad for me because it messes with various hot-reloading process managers (ones which leave your process running while it does an update underneath it, and then restarts your cluster workers), since during an `npm update` "./colors.js" might not exist, and if this function is first called during this time, then this module does not work.

Since we use this module (as part of https://github.com/Jimbly/node-pipe-to-browser) for streaming our log files from our server, it turns out that "high disk load" and "server is being updated" are states that very often overlap "immediate need to see the log files" =).
