### PR TITLE
Bugfix: No longer changes input theme

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ function createStream(options) {
     , stream
 
   colors = clone(colors[options.classes ? 'classes' : 'inline'])
-  colors = extend(colors, options.theme || {})
+  colors = extend(colors, clone(options.theme) || {})
 
   colors.resets = colors.resets || [{'0':false}]
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ansi-html-stream",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Stream ANSI terminal output to an HTML format.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Internally `createStream` mutates the `options.theme` input, causing
re-use of the same options to result in a bug.  This seems undesirable,
users should be able to write code like:

``` js
const ansi = require('ansi-html-stream');
const my_options = {theme: ...};

var stream1 = ansi(my_options);
var stream2 = ansi(my_options);
```

and expect both streams to work properly.

Before this fix the coloring for `stream2` would break. Now it doesn't.
